### PR TITLE
chore: update vs-agent-chart dependency version to v1.5.6 in Chart.yaml

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -27,6 +27,6 @@ maintainers:
 # Dependencies - VS Agent chart for DIDComm/Hologram protocol handling
 dependencies:
   - name: vs-agent-chart
-    version: v1.5.5 # ">=1.5.5"
+    version: v1.5.6 # ">=1.5.6"
     repository: "oci://registry-1.docker.io/io2060"
     condition: vs-agent-chart.enabled


### PR DESCRIPTION
Update Chart.yaml so it uses version 1.5.6 instead of 1.5.5